### PR TITLE
Add huntr.dev to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,5 @@
 huntr.dev init
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within polyfig, please submit a report via [huntr.dev](https://huntr.dev/repos/jamieslome/polyfig). Bounties and CVEs are automatically managed and allocated via the platform.


### PR DESCRIPTION
As requested through the platform, this will point your security policy to [huntr.dev](https://huntr.dev/repos/jamieslome/polyfig})